### PR TITLE
Resolved issue 20 for chrome.

### DIFF
--- a/usbong_store/application/views/auto-email/queue.php
+++ b/usbong_store/application/views/auto-email/queue.php
@@ -46,7 +46,7 @@ echo link_tag('assets/css/auto-email/queue.css');
             </div>
             <div class="form-group">
                 <label for="datetime">Target Kick</label>
-                <input type="datetime-local" class="form-control" name="start_datetime" value="<?php echo $default_datetime;?>" placeholder="<?php echo date('Y-m-d H:i:s'); ?>">
+                <input type="datetime" class="form-control" name="start_datetime" value="<?php echo $default_datetime;?>" placeholder="<?php echo date('Y-m-d H:i:s'); ?>">
             </div>
             <button name="create_button" type="submit" class="btn btn-success"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Create New Batch</button>
         </form>


### PR DESCRIPTION
HI MIke,

I changed the input type from datetime-locale to datetime.

Initially:

(1) when you open the page on chrome, no default data is placed

(2) when you save, it will fail because format is wrong

Now:

(1) when you open the page on chrome, the current datetime is placed

(2) data can now be saved

