### PR TITLE
Resolved Issue 35.

### DIFF
--- a/usbong_store/application/views/auto-email/email_frame_simple_template.php
+++ b/usbong_store/application/views/auto-email/email_frame_simple_template.php
@@ -120,7 +120,7 @@
         /* RESET STYLES */
         img { border: 0; outline: none; text-decoration: none; }
         table { border-collapse: collapse !important; }
-        body { margin: 0 !important; padding: 0 !important; width: 100% !important; }
+        body { font-family: arial, sans-serif; margin: 0 !important; padding: 0 !important; width: 100% !important; }
         /* iOS BLUE LINKS */
         a[x-apple-data-detectors] {
             color: inherit !important;


### PR DESCRIPTION
Hi Mike,

Prior to this issue, the email template we used had no font set.

It just so happened that arial was the default font used by gmail and we saw the email as arial.

I updated the template to make arial the default font.

If arial is not supported by the browser, it will fall back to sans-serif.

The combination of arial then sans-serif was chosen based on gmail default behavior. We can change it as you wish.

Have a good evening ahead!
